### PR TITLE
Second partv16update

### DIFF
--- a/Dockerfile-second_part
+++ b/Dockerfile-second_part
@@ -1,6 +1,6 @@
 #
 FROM davegill/wrf-coop:fourteenthtry
-MAINTAINER Dave Gill <gill@ucar.edu>
+MAINTAINER Kelly Werner <kkeene@ucar.edu>
 
 #RUN echo _HERE1_
 #RUN git clone https://github.com/davegill/WRF.git davegill/WRF \

--- a/Dockerfile-second_part
+++ b/Dockerfile-second_part
@@ -1,5 +1,5 @@
 #
-FROM davegill/wrf-coop:fourteenthtry
+FROM kkeene44/wrf-coop:version16
 MAINTAINER Kelly Werner <kkeene@ucar.edu>
 
 #RUN echo _HERE1_

--- a/Dockerfile-second_part
+++ b/Dockerfile-second_part
@@ -10,7 +10,7 @@ RUN git clone --recurse-submodule https://github.com/wrf-model/WRF.git WRF \
   && git checkout release-v4.4.1 \
   && cd ..
 
-RUN git clone https://github.com/davegill/SCRIPTS.git SCRIPTS \
+RUN git clone https://github.com/wrf-model/SCRIPTS.git SCRIPTS \
   && cp SCRIPTS/rd_l2_norm.py . && chmod 755 rd_l2_norm.py \
   && cp SCRIPTS/script.csh .    && chmod 755 script.csh    \
   && ln -sf SCRIPTS/Namelists . 

--- a/Dockerfile-second_part
+++ b/Dockerfile-second_part
@@ -2,12 +2,12 @@
 FROM kkeene44/wrf-coop:version16
 MAINTAINER Kelly Werner <kkeene@ucar.edu>
 
-RUN git clone https://github.com/wrf-model/WRF.git WRF \
+RUN git clone --recurse-submodule https://github.com/wrf-model/WRF.git WRF \
   && cd WRF \
-  && git checkout release-v4.2.1 \
+  && git checkout release-v4.4.2 \
   && git checkout master \
   && git checkout develop \
-  && git checkout release-v4.2 \
+  && git checkout release-v4.4.1 \
   && cd ..
 
 RUN git clone https://github.com/davegill/SCRIPTS.git SCRIPTS \

--- a/Dockerfile-second_part
+++ b/Dockerfile-second_part
@@ -2,15 +2,6 @@
 FROM kkeene44/wrf-coop:version16
 MAINTAINER Kelly Werner <kkeene@ucar.edu>
 
-#RUN echo _HERE1_
-#RUN git clone https://github.com/davegill/WRF.git davegill/WRF \
-#  && cd davegill/WRF \
-#  && git fetch origin +refs/pull/4/merge: \
-#  && git checkout -qf FETCH_HEAD \
-#  && cd .. \
-#  && mv WRF /wrf/WRF
-#RUN echo _HERE2_
-
 RUN git clone https://github.com/wrf-model/WRF.git WRF \
   && cd WRF \
   && git checkout release-v4.2.1 \


### PR DESCRIPTION
As part of updating the regression testing containers to v16, the file "Dockerfile-second_part" is updated to include the following modifications:

- Update maintainer from Dave Gill to Kelly Werner
- Updated to the latest built Docker container kkeene44/wrf-coop:version16
- Removed old commented-out code
- Updated the "git clone" command to include "--recurse-submodule," necessary for compiling and NoahMP
- Updated to now clone SCRIPTS/<various scripts> from the wrf-model/SCRIPTS repository, instead of davegill/SCRIPTS

These changes have all been tested, and along with PR #1, works well to build and run WRF. 