### PR TITLE
updated maintainer, container/version and github link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,19 @@
 #
-FROM davegill/wrf-coop:fourteenthtry
-MAINTAINER Dave Gill <gill@ucar.edu>
+FROM kkeene44/wrf-coop:version16
+MAINTAINER Kelly Werner <kkeene@ucar.edu>
 
-RUN git clone https://github.com/wrf-model/WRF.git WRF \
+RUN git clone --recurse-submodule https://github.com/wrf-model/WRF.git WRF \
   && cd WRF \
-  && git checkout release-v4.3.1 \
+  && git checkout release-v4.4.2 \
+  && git checkout master \
+  && git checkout develop \
+  && git checkout release-v4.4.1 \
   && cd ..
 
-RUN git clone https://github.com/davegill/SCRIPTS.git SCRIPTS \
+RUN git clone https://github.com/wrf-model/SCRIPTS.git SCRIPTS \
   && cp SCRIPTS/rd_l2_norm.py . && chmod 755 rd_l2_norm.py \
   && cp SCRIPTS/script.csh .    && chmod 755 script.csh    \
   && ln -sf SCRIPTS/Namelists . 
-
-RUN git clone https://github.com/davegill/wrf_feature_testing.git wrf_feature_testing \
-  && cd wrf_feature_testing && mv * .. && cd ..
-
-ARG argname=no_feature_tests
-RUN if [ "$argname" = "feature_tests" ]  ; then curl -SL https://www2.mmm.ucar.edu/wrf/dave/feature_data.tar.gz | tar -xzC /wrf ; fi
 
 VOLUME /wrf
 CMD ["/bin/tcsh"]

--- a/Dockerfile-sed
+++ b/Dockerfile-sed
@@ -1,6 +1,6 @@
 #
-FROM davegill/wrf-coop:fourteenthtry
-MAINTAINER Dave Gill <gill@ucar.edu>
+FROM kkeene44/wrf-coop:version16
+MAINTAINER Kelly Werner <kkeene@ucar.edu>
 
 #	DO NOT CHANGE UNDERSCORE GIT STRINGS
 #	THESE ARE USED FOR JENKINS TESTING
@@ -10,7 +10,7 @@ RUN git clone _GIT_URL_ WRF \
   && git checkout _GIT_BRANCH_ \
   && cd ..
 
-RUN git clone https://github.com/davegill/SCRIPTS.git SCRIPTS \
+RUN git clone https://github.com/wrf-model/SCRIPTS.git SCRIPTS \
   && cp SCRIPTS/rd_l2_norm.py . && chmod 755 rd_l2_norm.py \
   && cp SCRIPTS/script.csh .    && chmod 755 script.csh    \
   && ln -sf SCRIPTS/Namelists . 

--- a/build.csh
+++ b/build.csh
@@ -172,8 +172,8 @@ set SERIALBG  = ( F           F           F             F           F           
 set NP        = ( $PROCS      $PROCS      $PROCS        $PROCS      $PROCS      $PROCS         $PROCS      $PROCS      $PROCS      $PROCS      $PROCS      $PROCS      $PROCS      $PROCS      $PROCS      $PROCS      $PROCS      $PROCS                  $PROCS         )
 
 
-set SERIAL_OPT = 32
-set OPENMP_OPT = 33
+set SERIAL_OPT = 32 
+set OPENMP_OPT = 33 
 set    MPI_OPT = 34
 
 #	Info to determine if we eventually accomplish what we originally intended.


### PR DESCRIPTION
For now, files are being updated that pertain to building the necessary components for regression testing. The files Dockerfile, Dockerfile-sed, and build.csh have been updated with the new/correct maintainer, container repository and version, and the correct (wrf-model) github link for cloning. Files Dockerfile-first_part and Dockerfile-second_part were updated in previous PRs.

M   build.csh
M   Dockerfile
M   Dockerfile-sed

