### PR TITLE
updates to use kkeene44/wrf-coop:version16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
 #
-FROM davegill/wrf-coop:fifteenthtry
-MAINTAINER Dave Gill <gill@ucar.edu>
+FROM kkeene44/wrf-coop:version16
+MAINTAINER Kelly Werner <kkeene@ucar.edu>
 
 RUN git clone _FORK_/_REPO_.git WRF \
   && cd WRF \
   && git checkout _BRANCH_ \
   && cd ..
 
-RUN git clone https://github.com/davegill/SCRIPTS.git SCRIPTS \
+RUN git clone https://github.com/wrf-model/SCRIPTS.git SCRIPTS \
   && cp SCRIPTS/rd_l2_norm.py . && chmod 755 rd_l2_norm.py \
   && cp SCRIPTS/script.csh .    && chmod 755 script.csh    \
   && cp SCRIPTS/da_builds.csh . && chmod 755 da_builds.csh \
   && ln -sf SCRIPTS/Namelists . 
 
-RUN git clone https://github.com/davegill/wrf_feature_testing.git wrf_feature_testing \
+RUN git clone https://github.com/wrf-model/wrf_feature_testing.git wrf_feature_testing \
   && cd wrf_feature_testing && mv * .. && cd ..
 
 VOLUME /wrf

--- a/Dockerfile-first_part
+++ b/Dockerfile-first_part
@@ -1,6 +1,6 @@
 #
-FROM centos:7
-MAINTAINER Dave Gill <gill@ucar.edu>
+FROM kkeene44/wrf-coop:version16
+MAINTAINER Kelly Werner <kkeene@ucar.edu>
 
 ENV NML_VERSION 4.2
 

--- a/Dockerfile-second_part
+++ b/Dockerfile-second_part
@@ -1,6 +1,6 @@
 #
-FROM davegill/wrf-coop:fifteenthtry
-MAINTAINER Dave Gill <gill@ucar.edu>
+FROM kkeene44/wrf-coop:version16
+MAINTAINER Kelly Werner <kkeene@ucar.edu>
 
 #RUN echo _HERE1_
 #RUN git clone https://github.com/davegill/WRF.git davegill/WRF \
@@ -19,7 +19,7 @@ RUN git clone https://github.com/wrf-model/WRF.git WRF \
   && git checkout release-v4.2 \
   && cd ..
 
-RUN git clone https://github.com/davegill/SCRIPTS.git SCRIPTS \
+RUN git clone https://github.com/wrf-model/SCRIPTS.git SCRIPTS \
   && cp SCRIPTS/rd_l2_norm.py . && chmod 755 rd_l2_norm.py \
   && cp SCRIPTS/script.csh .    && chmod 755 script.csh    \
   && cp SCRIPTS/da_builds.csh . && chmod 755 da_builds.csh \

--- a/Dockerfile-sed
+++ b/Dockerfile-sed
@@ -1,6 +1,6 @@
 #
-FROM davegill/wrf-coop:fifteenthtry
-MAINTAINER Dave Gill <gill@ucar.edu>
+FROM kkeene44/wrf-coop:version16
+MAINTAINER Kelly Werner <kkeene@ucar.edu>
 
 #	DO NOT CHANGE UNDERSCORE GIT STRINGS
 #	THESE ARE USED FOR JENKINS TESTING
@@ -10,13 +10,13 @@ RUN git clone _GIT_URL_ WRF \
   && git checkout _GIT_BRANCH_ \
   && cd ..
 
-RUN git clone https://github.com/davegill/SCRIPTS.git SCRIPTS \
+RUN git clone https://github.com/wrf-model/SCRIPTS.git SCRIPTS \
   && cp SCRIPTS/rd_l2_norm.py . && chmod 755 rd_l2_norm.py \
   && cp SCRIPTS/script.csh .    && chmod 755 script.csh    \
   && cp SCRIPTS/da_builds.csh . && chmod 755 da_builds.csh \
   && ln -sf SCRIPTS/Namelists . 
 
-RUN git clone https://github.com/davegill/wrf_feature_testing.git wrf_feature_testing \
+RUN git clone https://github.com/wrf-model/wrf_feature_testing.git wrf_feature_testing \
   && cd wrf_feature_testing && mv * .. && cd ..
 
 VOLUME /wrf

--- a/README.md
+++ b/README.md
@@ -5,46 +5,16 @@ Build a container without WRF, then use that to build a container with WRF.
 It takes too long to always rebuild the container with WRF from scratch.
 
 ### Build first image 
-As of December 2019, this build / tag / push sequence must take place on a Linux machine. When trying to run this on a Mac, after 45 minutes of build time, you get:
+This build / tag / push sequence must take place on a Linux machine. When trying to run this on a Mac, after 45 minutes of build time, you get:
 ```
-etotheipi> docker push davegill/wrf-coop
-The push refers to repository [docker.io/davegill/wrf-coop]
+> docker push kkeene44/wrf-coop
+The push refers to repository [docker.io/kkeene44/wrf-coop]
 1c01cbaea4b8: Preparing 
-96dd30e2d9ec: Preparing 
-dbd99cfb48e8: Preparing 
-d2077632857f: Preparing 
-336a0a4ad4f4: Preparing 
+..
+..
 cc575835f8d4: Waiting 
-8844f6dd5393: Waiting 
-ef3923c49da1: Waiting 
-c57ce027abec: Waiting 
-d95b9b793e55: Waiting 
-d3d99b43d791: Waiting 
-987b6f729113: Waiting 
-aaf171c968f9: Waiting 
-38ae20a05bbf: Waiting 
-00cb8d467c5a: Waiting 
-9e8f7cbd1249: Waiting 
-d9767a7f89ec: Waiting 
-3e5c4dab6989: Waiting 
-d6304121d9e9: Waiting 
-2d3c96b16c25: Waiting 
-5239d65fffbc: Waiting 
-efb9e1f528df: Waiting 
-56c191e44487: Waiting 
-5dc1f34a4acf: Waiting 
-25c575725839: Waiting 
-d3709005b6e6: Waiting 
-1b5810566615: Waiting 
-217b19599265: Waiting 
-0e0618c626be: Waiting 
-2f6eb8fce98a: Waiting 
-cfd9822dfbcf: Waiting 
-a4cf543cbf0f: Waiting 
-bdc7e8c79d1f: Waiting 
-9c8f4f160f2a: Waiting 
-913a6c3d7109: Waiting 
-77b174a6a187: Waiting 
+..
+..
 denied: requested access to the resource is denied
 ```
 This image has the libs, data, directory structure, etc inside. The construction of this image uses the `Dockerfile-first_part` from this repository. This Docker setup was tested at https://github.com/davegill/travis_test. In the docker branch of the travis_test repo are the original `Dockerfile-template` and the `.travis.yml` files.
@@ -63,12 +33,12 @@ wrf-coop            latest              bd2082d1eb7d        19 minutes ago      
 centos              latest              9f38484d220f        5 weeks ago         202MB
 ```
 
-Once we have that image, we want to save it. That is the _WHOLE_ purpose of this exercise. Then we just pull it down and add in the WRF repository, and voi-fricking-la. Note, this is `firsttry`. I am at `fifteenthtry`.
+Once we have that image, we want to save it. That is the _WHOLE_ purpose of this exercise. Then we just pull it down and add in the WRF repository, and voi-fricking-la. 
 ```
-> docker tag bd2082d1eb7d davegill/wrf-coop:firsttry
+> docker tag bd2082d1eb7d kkeene44/wrf-coop:version16
 
-> docker push davegill/wrf-coop
-The push refers to repository [docker.io/davegill/wrf-coop]
+> docker push kkeene44/wrf-coop
+The push refers to repository [docker.io/kkeene44/wrf-coop]
 558695d708da: Pushed 
 e2d555398d6f: Pushed 
 8c6b7d91fee6: Pushed 
@@ -162,7 +132,7 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 > docker images
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
 wrf_regtest         latest              cb75a489c00c        About a minute ago   5.67 GB
-davegill/wrf-coop   fifteenthtry        c06fd248f249        6 hours ago          5.21 GB
+kkeene44/wrf-coop   version16           c06fd248f249        6 hours ago          5.21 GB
 ```
 ```
 > docker rmi 196313365c17 efc665da99ef
@@ -264,11 +234,11 @@ Each manufactured job script looks similar to this:
 ```
 #!/bin/csh
 #####################   TOP OF JOB    #####################
-touch /classroom/dave/wrf-coop/DOING_NOW_test_003s
-chmod 666 /classroom/dave/wrf-coop/DOING_NOW_test_003s
+touch /User/kkeene/wrf-coop/DOING_NOW_test_003s
+chmod 666 /User/kkeene/wrf-coop/DOING_NOW_test_003s
 echo TEST CASE = test_003s
 date
-set SHARED = /classroom/dave/wrf-coop
+set SHARED = /User/kkeene/wrf-coop
 #	Build: case = em, SERIAL
 echo Build container
 #docker run -it --name test_003s  -v $SHARED/OUTPUT:/wrf/wrfoutput wrf_regtest /bin/tcsh
@@ -320,9 +290,9 @@ docker stop test_003s
 date
 docker rm test_003s
 date
-touch /classroom/dave/wrf-coop/COMPLETE_test_003s
-chmod 666 /classroom/dave/wrf-coop/COMPLETE_test_003s
-mv /classroom/dave/wrf-coop/DOING_NOW_test_003s /classroom/dave/wrf-coop/COMPLETE_test_003s
+touch /User/kkeene/wrf-coop/COMPLETE_test_003s
+chmod 666 /User/kkeene/wrf-coop/COMPLETE_test_003s
+mv /User/kkeene/wrf-coop/DOING_NOW_test_003s /User/kkeene/wrf-coop/COMPLETE_test_003s
 #####################   END OF JOB    #####################
 ```
 

--- a/README_user.md
+++ b/README_user.md
@@ -72,8 +72,8 @@ Several types of tests are accessible within this docker testing system.
 |ARW 2D hill         |     4     |   2D  |  yes   |        |     |   ideal    | N |
 
 2. The testing uses the WRF run-time configuration file, `namelist.input` to exercise an expandable list of features that are all included within the WRF docker container. The current list of tests conducted is produced from information within two github respositories:
-   * All available namelists choices for em_real: https://github.com/davegill/SCRIPTS/tree/master/Namelists/weekly/em_real/MPI
-   * Requested tests are defined in: https://github.com/davegill/wrf-coop/blob/regression+feature/build.csh
+   * All available namelists choices for em_real: https://github.com/wrf-model/SCRIPTS/tree/master/Namelists/weekly/em_real/MPI
+   * Requested tests are defined in: https://github.com/wrf-model/wrf-coop/blob/regression+feature/build.csh
 
 | **Test** | **MP** | **CU** | **LW** | **SW** | **PBL** | **SFC** | **LSM** | **URB** |
 | ------|:--:|:--:|:--:|:--:|:--: |:--: |:--: |:--: |
@@ -128,8 +128,8 @@ The topography for the nested domains over the central US for the 30/10-km ARW r
 Currrently all of the restart builds are for ARW em_real. Since the comparison is between the first (the full-length simulation) and the second (shorter, restart simulation) WRF runs, there is no need to try out different parallel options. The time period is 2016 Mar 23-24 0000 UTC, though again the simulations are very short: 12 minutes in duration.
 
 The testing uses groupings of three WRF run-time configuration files, `namelist.input.1`, `namelist.input.3`, and `namelist.input.3` to exercise an expandable list of features that are all included within the WRF docker container. The current list of tests conducted is produced from information within two githhub respositories:
-   * All available namelists choices for em_real: https://github.com/davegill/wrf_feature_testing/tree/main/cases
-   * Requested tests are defined in: https://github.com/davegill/wrf-coop/blob/regression+feature/build.csh
+   * All available namelists choices for em_real: https://github.com/wrf-model/wrf_feature_testing/tree/main/cases
+   * Requested tests are defined in: https://github.com/wrf-model/wrf-coop/blob/regression+feature/build.csh
 
 
 | **Test** | **SUITE** | **URB** | **DFI** |
@@ -152,7 +152,7 @@ The following describe the required steps run the WRF regression system on you l
 
 2. To start the process of constructing a working WRF docker container, clone the WRF-specific wrf-coop repository, and checkout the specific branch used by the automated testing. Once you have the docker application running on your machine, this repository contains the code that eventually builds the container structures for WRF.
 ```
-git clone https://github.com/davegill/wrf-coop
+git clone https://github.com/wrf-model/wrf-coop
 cd wrf-coop
 git checkout regression+feature
 ```
@@ -164,20 +164,20 @@ git checkout regression+feature
 Here is the entire Dockerfile for ARW: `Dockerfile`:
 ```
 #
-FROM davegill/wrf-coop:fifteenththtry
-MAINTAINER Dave Gill <gill@ucar.edu>
+FROM kkeene44/wrf-coop:version16
+MAINTAINER Kelly Werner <kkeene@ucar.edu>
 
 RUN git clone _FORK_/_REPO_.git WRF \
   && cd WRF \
   && git checkout _BRANCH_ \
   && cd ..
 
-RUN git clone https://github.com/davegill/SCRIPTS.git SCRIPTS \
+RUN git clone https://github.com/wrf-model/SCRIPTS.git SCRIPTS \
   && cp SCRIPTS/rd_l2_norm.py . && chmod 755 rd_l2_norm.py \
   && cp SCRIPTS/script.csh .    && chmod 755 script.csh    \
   && ln -sf SCRIPTS/Namelists . 
   
-RUN git clone https://github.com/davegill/wrf_feature_testing.git wrf_feature_testing \
+RUN git clone https://github.com/wrf-model/wrf_feature_testing.git wrf_feature_testing \
   && cd wrf_feature_testing && mv * .. && cd ..
 
 VOLUME /wrf
@@ -221,21 +221,21 @@ docker images
 
 REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
 wrf-regtest                   latest              861fc54c4a6a        6 days ago          7.28 GB
-docker.io/davegill/wrf-coop   fifteenthtry        7991cdc121de        2 weeks ago         6.71 GB
+docker.io/kkeene44/wrf-coop  version16           7991cdc121de        2 weeks ago         6.71 GB
 ```
 
 ### Contruct the docker containers<a name="Constrcutcontainers"/>
 
 1. Choose a shared directory for docker
 
-To share data and files back and forth between the host OS and the docker container, a user-defined assignment maps a local host OS directory to a directory inside of the WRF container. For example, let's assume that the existing local directory on the host OS is `/users/gill/DOCKER_STUFF`.
+To share data and files back and forth between the host OS and the docker container, a user-defined assignment maps a local host OS directory to a directory inside of the WRF container. For example, let's assume that the existing local directory on the host OS is `/users/kkeene/DOCKER_STUFF`.
 
 2. Build the container 
 
 Each container takes about 30 seconds to complete (nothing to download, just local processing). The commands for each container should each be issued from separate terminal windows from the host OS (i.e. don't issue a docker command inside of a WRF docker container).
 
 ```
-docker run -it --name ARW -v /users/gill/DOCKER_STUFF:/wrf/wrfoutput wrf_regtest /bin/tcsh
+docker run -it --name ARW -v /users/kkeene/DOCKER_STUFF:/wrf/wrfoutput wrf_regtest /bin/tcsh
 ```
 You are now in the ARW container. You'll notice that the prompt has changed:
 ```
@@ -337,10 +337,10 @@ cp wrfout_d01_2000-01-24_12:00:00 /wrf/wrfoutput/
 
 In the host OS, go to the shared volume directory:
 ```
-cd /users/gill/DOCKER_STUFF
+cd /users/kkeene/DOCKER_STUFF
 ls -ls
 total 78936
-78936 -rw-r--r--  1 gill  1500  40413808 Apr  3 14:19 wrfout_d01_2000-01-24_12:00:00
+78936 -rw-r--r--  1 kkeene  1500  40413808 Apr  3 14:19 wrfout_d01_2000-01-24_12:00:00
 ```
 ### Compare the simulation results<a name="Compareresults"/>
 
@@ -1042,7 +1042,7 @@ What docker images are available to remove:
 docker images
 REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
 wrf_regtest         latest              cb75a489c00c        About a minute ago   5.67 GB
-davegill/wrf-coop   fifteenthtry        c06fd248f249        6 hours ago          5.21 GB
+kkeene44/wrf-coop   version16           c06fd248f249        6 hours ago          5.21 GB
 ```
 As mentioned previously, leave the `wrf-coop` images alone. To remove the image that made the `ARW` container (in the above example):
 ```

--- a/build.csh
+++ b/build.csh
@@ -355,7 +355,7 @@ echo "#	container, and then does some seasonal pruning" >> single_end.csh
 echo "" >> single_end.csh
 echo "date" >> single_end.csh
 echo 'docker rmi $1' >> single_end.csh
-echo "set hash = "'`'"docker images | grep davegill |  awk '{print  " '$3' "}'" ' `' >> single_end.csh
+echo "set hash = "'`'"docker images | grep kkeene44 |  awk '{print  " '$3' "}'" ' `' >> single_end.csh
 echo '#docker rmi --force $hash' >> single_end.csh
 echo "docker volume prune -f" >> single_end.csh
 echo "docker system df" >> single_end.csh


### PR DESCRIPTION
Modified several files to reflect that we now want to use Docker image kkeene44/wrf-coop:version16, as well as using the GitHub repositories from wrf-model now, instead of davegill.


M   Dockerfile
M   Dockerfile-first_part
M   Dockerfile-second_part
M   Dockerfile-sed
M   README.md
M   README_user.md
M   build.csh